### PR TITLE
optimize dll, provide snupkg and use continuous integration build option

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -16,39 +16,27 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4
-        
+
       - name: Setup .NET Core SDK
         uses: actions/setup-dotnet@v1.7.2
         with:
-            dotnet-version: '5.0.100'
-  
+            dotnet-version: '5.0.201'
+
       - name: Build (Release)
         run: dotnet build --configuration Release
-  
+
       - name: Test (Release)
-        run: dotnet test --configuration Release
+        run: dotnet test --configuration Release --no-build --no-restore
 
       - name: Pack (Release)
         run: |
-            dotnet pack src\EasyCompressor --configuration Release
-            dotnet pack src\EasyCompressor.BrotliNET --configuration Release
-            dotnet pack src\EasyCompressor.LZ4 --configuration Release
-            dotnet pack src\EasyCompressor.LZMA --configuration Release
-            dotnet pack src\EasyCompressor.Snappy --configuration Release
-            dotnet pack src\EasyCompressor.Zstd --configuration Release
-            dotnet pack src\EasyCaching.Extensions.EasyCompressor --configuration Release
-            
+            dotnet pack --configuration Release --output ./nuget --no-build --no-restore
+
       - name: Publish
         if: github.event_name == 'push'
-        run: |      
+        run: |
             if ( "${{github.ref}}" -match "^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$" ) {
-                dotnet nuget push src\EasyCompressor\bin\Release\*.nupkg -s nuget.org -k ${{secrets.NUGET_TOKEN}} --no-symbols true
-                dotnet nuget push src\EasyCompressor.BrotliNET\bin\Release\*.nupkg -s nuget.org -k ${{secrets.NUGET_TOKEN}} --no-symbols true
-                dotnet nuget push src\EasyCompressor.LZ4\bin\Release\*.nupkg -s nuget.org -k ${{secrets.NUGET_TOKEN}} --no-symbols true
-                dotnet nuget push src\EasyCompressor.LZMA\bin\Release\*.nupkg -s nuget.org -k ${{secrets.NUGET_TOKEN}} --no-symbols true
-                dotnet nuget push src\EasyCompressor.Snappy\bin\Release\*.nupkg -s nuget.org -k ${{secrets.NUGET_TOKEN}} --no-symbols true
-                dotnet nuget push src\EasyCompressor.Zstd\bin\Release\*.nupkg -s nuget.org -k ${{secrets.NUGET_TOKEN}} --no-symbols true
-                dotnet nuget push src\EasyCaching.Extensions.EasyCompressor\bin\Release\*.nupkg -s nuget.org -k ${{secrets.NUGET_TOKEN}} --no-symbols true
+                dotnet nuget push ./nuget/*.nupkg -s nuget.org -k ${{secrets.NUGET_TOKEN}} --skip-duplicate
             } else {
                 echo "publish is only enabled by tagging with a release tag"
             }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,0 +1,35 @@
+<Project>
+    <PropertyGroup>
+        <Authors>Mohammad Javad Ebrahimi</Authors>
+        <Company>Mohammad Javad Ebrahimi</Company>
+        <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
+        <Description>
+            A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
+        </Description>
+        <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate</PackageTags>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/mjebrahimi/EasyCompressor</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
+        <RepositoryType>git</RepositoryType>
+        <PublishRepositoryUrl>true</PublishRepositoryUrl>
+        <EmbedUntrackedSources>true</EmbedUntrackedSources>
+        <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+        <PackageIcon>EasyCompressor.png</PackageIcon>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+        <IncludeSymbols>true</IncludeSymbols>
+        <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(GITHUB_ACTIONS)' == 'true'">
+        <ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <None Include="$(MSBuildThisFileDirectory)\EasyCompressor.png" Pack="true" PackagePath="" />
+    </ItemGroup>
+</Project>

--- a/src/EasyCaching.Extensions.EasyCompressor/EasyCaching.Extensions.EasyCompressor.csproj
+++ b/src/EasyCaching.Extensions.EasyCompressor/EasyCaching.Extensions.EasyCompressor.csproj
@@ -9,39 +9,10 @@
     <Version>1.3.0</Version>
     <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-    <Authors>Mohammad Javad Ebrahimi</Authors>
-    <Company>Mohammad Javad Ebrahimi</Company>
-    <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
-    <Description>
-      A compressor upon EasyCaching serializers using EasyCompressor.
-
-      This library is very useful for compressing cache data especially for distributed cache (such as Redis) to improve performance by reducing memory usage and network traffic and subsequently.
-
-      EasyCaching is the best caching abstraction library which supports many providers and serializers.
-
-      A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
-    </Description>
-    <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate EasyCaching Cache Caching Memory In-Memory Distributed DistributedCache Serialization MessagePack Json</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>EasyCompressor.png</PackageIcon>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DebugType>embedded</DebugType>
-    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="EasyCaching.Core" Version="1.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\EasyCompressor.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/EasyCompressor.BrotliNET/EasyCompressor.BrotliNET.csproj
+++ b/src/EasyCompressor.BrotliNET/EasyCompressor.BrotliNET.csproj
@@ -9,24 +9,6 @@
     <Version>1.3.0</Version>
     <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-    <Authors>Mohammad Javad Ebrahimi</Authors>
-    <Company>Mohammad Javad Ebrahimi</Company>
-    <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
-    <Description>
-      A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
-    </Description>
-    <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>EasyCompressor.png</PackageIcon>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DebugType>embedded</DebugType>
-    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,11 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="Brotli.NET" Version="2.0.4.2" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\EasyCompressor.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/EasyCompressor.LZ4/EasyCompressor.LZ4.csproj
+++ b/src/EasyCompressor.LZ4/EasyCompressor.LZ4.csproj
@@ -9,24 +9,6 @@
     <Version>1.3.0</Version>
     <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-    <Authors>Mohammad Javad Ebrahimi</Authors>
-    <Company>Mohammad Javad Ebrahimi</Company>
-    <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
-    <Description>
-      A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
-    </Description>
-    <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>EasyCompressor.png</PackageIcon>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DebugType>embedded</DebugType>
-    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
@@ -36,11 +18,6 @@
   <ItemGroup>
     <PackageReference Include="K4os.Compression.LZ4.Streams" Version="1.2.6" />
     <PackageReference Include="K4os.Compression.LZ4" Version="1.2.6" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\EasyCompressor.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/EasyCompressor.LZMA/EasyCompressor.LZMA.csproj
+++ b/src/EasyCompressor.LZMA/EasyCompressor.LZMA.csproj
@@ -9,24 +9,6 @@
     <Version>1.3.0</Version>
     <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-    <Authors>Mohammad Javad Ebrahimi</Authors>
-    <Company>Mohammad Javad Ebrahimi</Company>
-    <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
-    <Description>
-      A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
-    </Description>
-    <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>EasyCompressor.png</PackageIcon>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DebugType>embedded</DebugType>
-    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,11 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="LZMA-SDK" Version="19.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\EasyCompressor.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/EasyCompressor.Snappy/EasyCompressor.Snappy.csproj
+++ b/src/EasyCompressor.Snappy/EasyCompressor.Snappy.csproj
@@ -9,24 +9,6 @@
     <Version>1.3.0</Version>
     <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-    <Authors>Mohammad Javad Ebrahimi</Authors>
-    <Company>Mohammad Javad Ebrahimi</Company>
-    <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
-    <Description>
-      A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
-    </Description>
-    <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>EasyCompressor.png</PackageIcon>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DebugType>embedded</DebugType>
-    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,11 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="Snappy.Standard" Version="0.2.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\EasyCompressor.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/EasyCompressor.Zstandard/EasyCompressor.Zstandard.csproj
+++ b/src/EasyCompressor.Zstandard/EasyCompressor.Zstandard.csproj
@@ -9,24 +9,6 @@
     <Version>1.3.0</Version>
     <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-    <Authors>Mohammad Javad Ebrahimi</Authors>
-    <Company>Mohammad Javad Ebrahimi</Company>
-    <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
-    <Description>
-      A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
-    </Description>
-    <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>EasyCompressor.png</PackageIcon>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DebugType>embedded</DebugType>
-    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,11 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="Zstandard.Net" Version="1.1.7" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\EasyCompressor.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/src/EasyCompressor.Zstd/EasyCompressor.Zstd.csproj
+++ b/src/EasyCompressor.Zstd/EasyCompressor.Zstd.csproj
@@ -9,24 +9,6 @@
     <Version>1.3.0</Version>
     <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-    <Authors>Mohammad Javad Ebrahimi</Authors>
-    <Company>Mohammad Javad Ebrahimi</Company>
-    <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
-    <Description>
-      A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
-    </Description>
-    <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>EasyCompressor.png</PackageIcon>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DebugType>embedded</DebugType>
-    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup>
@@ -35,11 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="ZstdNet" Version="1.4.5" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\EasyCompressor.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <!--

--- a/src/EasyCompressor/EasyCompressor.csproj
+++ b/src/EasyCompressor/EasyCompressor.csproj
@@ -9,24 +9,6 @@
     <Version>1.3.0</Version>
     <PackageVersion>1.3.0</PackageVersion>
     <AssemblyVersion>1.3.0</AssemblyVersion>
-    <Authors>Mohammad Javad Ebrahimi</Authors>
-    <Company>Mohammad Javad Ebrahimi</Company>
-    <Copyright>Copyright © Mohammad Javad Ebrahimi 2020</Copyright>
-    <Description>
-      A compression library that implements many compression algorithms such as LZ4, Zstd, LZMA, Snappy, Brotli, GZip, and Deflate. It helps you to improve performance by reducing Memory Usage and Network Traffic for caching.
-    </Description>
-    <PackageTags>Compression Decompression Compress Decompress Compressor Zstd Zstandard LZMA LZ4 Snappy Brotli GZip Deflate</PackageTags>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/mjebrahimi/EasyCompressor</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <GeneratePackageOnBuild Condition="'$(Configuration)'=='Release'">true</GeneratePackageOnBuild>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <PackageIcon>EasyCompressor.png</PackageIcon>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <DebugType>embedded</DebugType>
-    <Optimize>false</Optimize>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0' OR '$(TargetFramework)'=='netstandard2.1' OR '$(TargetFramework)'=='net461' OR '$(TargetFramework)'=='netcoreapp2.1'">
@@ -36,14 +18,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)'=='netstandard1.1' OR '$(TargetFramework)'=='net45'">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.1.1"/>
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="..\EasyCompressor.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
 </Project>

--- a/test/EasyCompressor.Benchmark/EasyCompressor.Benchmark.csproj
+++ b/test/EasyCompressor.Benchmark/EasyCompressor.Benchmark.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
@mjebrahimi When attempting to benchmark the dotnet benchmark tool complains about the EasyCompressor package not being optimized.

So I thought I go ahead and fix that but noticed you had a lot of copy pasta in your csproj files.

Noticed also that not all nuget packages were pushed as in EasyCompressor.Zstandard is not pushed to nuget, which seems to be related to manually typing out each dotnet nuget push in github action.

Than checking the NuGet package with https://github.com/NuGetPackageExplorer/NuGetPackageExplorer there were a few issues that.

Would be great with a new release that is built with a more recent compiler.

Instead of embedding symbols, a snupkg for nuget.org is a better option.
https://docs.microsoft.com/en-us/nuget/create-packages/symbol-packages-snupkg

The version could properly move to Directory.Build.props if you wish to always maintain the same versioning.